### PR TITLE
PHP type hinting rule tweak

### DIFF
--- a/.changeset/big-planes-cry.md
+++ b/.changeset/big-planes-cry.md
@@ -1,0 +1,5 @@
+---
+"php-coding-standards": patch
+---
+
+Remove UselessAnnotation type checks due to conflict with other rules

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -45,9 +45,14 @@
 		<exclude-pattern>*/lib/*</exclude-pattern>
 		<exclude-pattern>*/classes/*</exclude-pattern>
 	</rule>
-	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation"/>
+	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
-	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+		<!-- Required as WP standard requires mandatory commented parameter type hints -->
+		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation"/>
+	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>


### PR DESCRIPTION
- `ParameterTypeHint.UselessAnnotation` needs removing to avoid conflict with Squiz.Commenting.FunctionComment.MissingParamComment
- `ReturnTypeHint.UselessAnnotation` doesn't but for now I'd like to keep simple return type hint comments so that the entire team gets used to what they mean. If we decide to remove comments that duplicate the hint itself in the future then this will be an easy auto-format change that's built into the linter.

