### PR TITLE
Allow extra param docs for functions

### DIFF
--- a/.changeset/true-jokes-know.md
+++ b/.changeset/true-jokes-know.md
@@ -1,0 +1,5 @@
+---
+"php-coding-standards": minor
+---
+
+Allow extra param docs for functions

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,6 +14,7 @@
 		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound"/>
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
+		<exclude name="Squiz.Commenting.FunctionComment.ExtraParamComment"/>
 	</rule>
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
 	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>


### PR DESCRIPTION
WordPress contains a lot of actions and filters which require having a function with parameters defined by WordPress. Sometimes we don't need to use all the parameters so we can leave them off the function, but it's easier to document all the parameters at once.

Allowing extra param docs allows us to include the documentation for unused parameters for later use, instead of having to add the variable and also document it on use.