### PR TITLE
Allow mixed type to be used

### DIFF
--- a/.changeset/cruel-falcons-stay.md
+++ b/.changeset/cruel-falcons-stay.md
@@ -1,0 +1,5 @@
+---
+"php-coding-standards": minor
+---
+
+Allow mixed type to be used

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -54,7 +54,6 @@
 		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation"/>
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
-	<rule ref="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>


### PR DESCRIPTION
Because of the lack of an `unknown` style type, we should unblock use of mixed as it is needed in some use cases, even if it's discouraged from wider use.